### PR TITLE
[BUG] Inferenced responses accumulating over question types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,38 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+
+# Model files and caches
+models--*/
+*.safetensors
+*.bin
+.locks/
+
+# Output directories
+outputs/
+results/
+
+# HuggingFace cache
+.cache/
+transformers_cache/
+
+# Dataset files (if large)
+*.csv
+!data/agentcoma_*.csv  # Keep original dataset files
+
+# Jupyter notebook checkpoints
+.ipynb_checkpoints/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Logs
+*.log
+logs/
+
+# Temporary files
+*.tmp
+*.temp

--- a/eval.py
+++ b/eval.py
@@ -198,26 +198,26 @@ def discover_inference_files(output_folder, model_name, split, sampling_config=N
 
 def discover_all_models(output_folder, split):
     """Auto-discover all models in the output folder based on file patterns.
-    
+
     Args:
         output_folder: Path to folder containing inference results
         split: Data split ('dev' or 'test')
-    
+
     Returns:
         List of model names found in the output folder
     """
     pattern = f"{split}_*.csv"
     files = glob.glob(os.path.join(output_folder, pattern))
-    
+
     models = set()
     for file in files:
         filename = os.path.basename(file)
-        parts = filename.replace('.csv', '').split('_')
+        parts = filename.replace(".csv", "").split("_")
         if len(parts) >= 4:
             # Extract model name (between split and question_type)
             model_name = parts[1]
             models.add(model_name)
-    
+
     return sorted(list(models))
 
 
@@ -316,26 +316,26 @@ if __name__ == "__main__":
         sys.exit(1)
 
     output_folder, split = sys.argv[1:3]
-    
+
     # Discover all models in the output folder
     models = discover_all_models(output_folder, split)
     if not models:
         print(f"No models found in {output_folder} for {split} split")
         sys.exit(1)
-    
+
     print(f"Found models: {', '.join(models)}")
-    
+
     all_results = []
     for model_name in models:
-        print(f"\n{'='*70}")
+        print(f"\n{'=' * 70}")
         print(f"Evaluating model: {model_name}")
-        print(f"{'='*70}")
-        
+        print(f"{'=' * 70}")
+
         all_configs = discover_inference_files(output_folder, model_name, split)
         if not all_configs:
             print(f"No files found for {model_name} {split}")
             continue
-        
+
         for data_paths in all_configs:
             # Extract full sampling config name from filename
             sample_file = list(data_paths.values())[0]
@@ -346,11 +346,11 @@ if __name__ == "__main__":
                 config_name = "_".join(parts[3:])  # Everything after question type
             else:
                 config_name = parts[-1]
-            
-            print(f"\n{'-'*50}")
+
+            print(f"\n{'-' * 50}")
             print(f"Evaluating configuration: {config_name}")
-            print(f"{'-'*50}")
-            
+            print(f"{'-' * 50}")
+
             # Determine sampling method
             if "top_p" in config_name:
                 sampling_method = "top_p"
@@ -360,14 +360,10 @@ if __name__ == "__main__":
                 sampling_method = "greedy"
             else:
                 sampling_method = "unknown"
-            
+
             metrics = evaluate_all_question_types_and_print_report(data_paths, split, output_folder)
-            all_results.append({
-                "model_config": f"{model_name}_{config_name}", 
-                "sampling_method": sampling_method,
-                **metrics
-            })
-    
+            all_results.append({"model_config": f"{model_name}_{config_name}", "sampling_method": sampling_method, **metrics})
+
     # Save combined results
     results_df = pd.DataFrame(all_results)
     results_csv_path = os.path.join(output_folder, f"evaluation_results_{split}.csv")

--- a/eval.py
+++ b/eval.py
@@ -11,11 +11,6 @@ from tqdm import tqdm
 
 openai_api_key = os.environ["OPENAI_API_KEY"]
 
-def load_api_client():
-    """Loads the OpenAI API client with the given API key."""
-    api_key = openai_api_key
-    openai_client = OpenAI(api_key=api_key)
-    return openai_client
 
 def call_api(client, model_id, input_text):
     """Calls the OpenAI API with the given model and input text."""
@@ -78,7 +73,7 @@ def evaluate_answer(question, gold_answer, response, client, eval_model_id="gpt-
 def check_text(question, true, pred):
   """LLM-as-a-judge eval."""
   assert len(question) == len(true) == len(pred)
-  client = load_api_client()
+  client = OpenAI(api_key=openai_api_key)
   res = []
   for i in tqdm(range(len(pred))):
     is_correct = 0

--- a/eval.py
+++ b/eval.py
@@ -12,13 +12,11 @@ from tqdm import tqdm
 openai_api_key = os.environ["OPENAI_API_KEY"]
 
 
-
-
-def parse_answer(answer, pattern:str="so the final answer is:"):
+def parse_answer(answer, pattern: str = "so the final answer is:"):
     """Extracts number from answer."""
     if pattern in str(answer).lower():
         answer = answer.split(pattern)[-1]
-        answer = answer.strip().strip("\n").strip('\\n')
+        answer = answer.strip().strip("\n").strip("\\n")
         answer = answer.replace(",", "")
         try:
             answer = re.findall(r"[-+]?\d*\.\d+|\d+", answer)[-1]
@@ -26,13 +24,14 @@ def parse_answer(answer, pattern:str="so the final answer is:"):
             answer = 0
     else:
         answer = str(answer).split("\n")[-1]
-        answer = answer.strip().strip("\n").strip('\\n')
+        answer = answer.strip().strip("\n").strip("\\n")
         answer = answer.replace(",", "")
         try:
             answer = re.findall(r"[-+]?\d*\.\d+|\d+", answer)[-1]
         except:
             answer = 0
     return answer
+
 
 def accuracy(true, pred):
     """Computes exact match accuracy."""
@@ -50,16 +49,14 @@ def accuracy(true, pred):
             is_accurate.append(0)
     return is_accurate
 
+
 def evaluate_answer(question, gold_answer, response, client, eval_model_id="gpt-4o-2024-08-06"):
     """Evaluates a text response against the gold answer."""
-    eval_prompt = (f'''Evaluate the following response to the question, and determine if the answer is correct given the reference. Respond only with "yes" if the answer is equivalent, or "no" if it is not.
+    eval_prompt = f"""Evaluate the following response to the question, and determine if the answer is correct given the reference. Respond only with "yes" if the answer is equivalent, or "no" if it is not.
     Question: {question}
     Response: {response}
-    Reference: {gold_answer}''')
-    response = client.responses.create(
-        model=eval_model_id,
-        input=eval_prompt
-    )
+    Reference: {gold_answer}"""
+    response = client.responses.create(model=eval_model_id, input=eval_prompt)
     eval_response = response.output_text
     if "yes" in eval_response.lower():
         result = True
@@ -67,34 +64,35 @@ def evaluate_answer(question, gold_answer, response, client, eval_model_id="gpt-
         result = False
     return result
 
-def check_text(question, true, pred):
-  """LLM-as-a-judge eval."""
-  assert len(question) == len(true) == len(pred)
-  client = OpenAI(api_key=openai_api_key)
-  res = []
-  for i in tqdm(range(len(pred))):
-    is_correct = 0
-    try:
-      text = pred[i].split("So the final answer is:")[1].strip()
-      for ga in ast.literal_eval(true[i]):
-        if evaluate_answer(question[i], ga, text, client):
-          is_correct = 1
-          break
-      if not is_correct:
-        for ga in ast.literal_eval(true[i]):
-          if evaluate_answer(question[i], ga, pred[i], client):
-            is_correct = 1
-            break
-    except:
-      for ga in ast.literal_eval(true[i]):
-        if evaluate_answer(question[i], ga, pred[i], client):
-          is_correct = 0
-          break
-    res.append(is_correct)
-  return res
 
-def evaluate_all_question_types_and_print_report(data_paths, data_split,
-                                                 output_folder=None):
+def check_text(question, true, pred):
+    """LLM-as-a-judge eval."""
+    assert len(question) == len(true) == len(pred)
+    client = OpenAI(api_key=openai_api_key)
+    res = []
+    for i in tqdm(range(len(pred))):
+        is_correct = 0
+        try:
+            text = pred[i].split("So the final answer is:")[1].strip()
+            for ga in ast.literal_eval(true[i]):
+                if evaluate_answer(question[i], ga, text, client):
+                    is_correct = 1
+                    break
+            if not is_correct:
+                for ga in ast.literal_eval(true[i]):
+                    if evaluate_answer(question[i], ga, pred[i], client):
+                        is_correct = 1
+                        break
+        except:
+            for ga in ast.literal_eval(true[i]):
+                if evaluate_answer(question[i], ga, pred[i], client):
+                    is_correct = 0
+                    break
+        res.append(is_correct)
+    return res
+
+
+def evaluate_all_question_types_and_print_report(data_paths, data_split, output_folder=None):
     """Evaluates all commonsense-only, math-only and compositional answers of a
       model, saves 0-1 scores for each answer for each csv file (overwrites the
       file), and computes the compositionality gap between the proportion of
@@ -123,65 +121,57 @@ def evaluate_all_question_types_and_print_report(data_paths, data_split,
         assert len(ground_truths) == len(answers), f"""The lengths of the outputs and the ground truths in {path} do not correspond.
 You have set to evaluate on the {data_split} split. Are you sure you are providing an output file for the correct split?"""
         if "commonsense" in path:
-          print("Evaluating commonsense-only answers...")
-          acc = check_text(ground_truths["question_commonsense"], 
-                          ground_truths["answers_commonsense"], 
-                          answers['generation'])
-          accs["commonsense"] = acc
+            print("Evaluating commonsense-only answers...")
+            acc = check_text(ground_truths["question_commonsense"], ground_truths["answers_commonsense"], answers["generation"])
+            accs["commonsense"] = acc
         if "math" in path:
-          print("Evaluating math-only answers...")
-          acc = accuracy(ground_truths["answer_math"],
-                        answers["generation"])
-          accs["math"] = acc
+            print("Evaluating math-only answers...")
+            acc = accuracy(ground_truths["answer_math"], answers["generation"])
+            accs["math"] = acc
         elif "composition" in path:
-          print("Evaluating compositional answers...")
-          acc = accuracy(ground_truths["answer_composition"],
-                        answers["generation"])
-          accs["composition"] = acc
+            print("Evaluating compositional answers...")
+            acc = accuracy(ground_truths["answer_composition"], answers["generation"])
+            accs["composition"] = acc
 
         answers["accuracy"] = acc
         answers.to_csv(data_paths[path])
 
-    commonsense_acc = np.mean(accs['commonsense'])
-    math_acc = np.mean(accs['math'])
-    both_steps_acc = len(
-       [x for x in zip(accs['commonsense'], accs['math']) if x==(1,1)]
-      ) / len(accs['math'])  
-    comp_acc = np.mean(accs['composition'])  
+    commonsense_acc = np.mean(accs["commonsense"])
+    math_acc = np.mean(accs["math"])
+    both_steps_acc = len([x for x in zip(accs["commonsense"], accs["math"]) if x == (1, 1)]) / len(accs["math"])
+    comp_acc = np.mean(accs["composition"])
     comp_gap = comp_acc - both_steps_acc
 
     accuracy_report = f"""
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   PERFORMANCE REPORT FOR {data_split} DATA SPLIT
   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  Commonsense-only accuracy: { commonsense_acc }
+  Commonsense-only accuracy: {commonsense_acc}
   ---
-  Math-only accuracy: { math_acc }
+  Math-only accuracy: {math_acc}
   ---
-  Percentage of questions where both reasoning steps are solved correctly in isolation: {
-    both_steps_acc
-  }
+  Percentage of questions where both reasoning steps are solved correctly in isolation: {both_steps_acc}
   ---
-  Compositional accuracy: { comp_acc }
+  Compositional accuracy: {comp_acc}
   ---
-  Compositionality gap: { comp_gap }
+  Compositionality gap: {comp_gap}
   """
 
     print(accuracy_report)
 
     if output_folder is not None:
-       print("Saving evaluation report...")
-       uid = uuid.uuid4()
-       with open(os.path.join(output_folder,
-                              f"report_{uid.hex}.txt"), "w") as text_file:
-          text_file.write(accuracy_report)
-       print("Done.")
-        
+        print("Saving evaluation report...")
+        uid = uuid.uuid4()
+        with open(os.path.join(output_folder, f"report_{uid.hex}.txt"), "w") as text_file:
+            text_file.write(accuracy_report)
+        print("Done.")
+
+
 if __name__ == "__main__":
     data_paths = {
-        # paste the paths to the inference csv files here. 
-        'commonsense_inference_data_path': "",
-        'math_inference_data_path': "",
-        'composition_inference_data_path': ""
+        # paste the paths to the inference csv files here.
+        "commonsense_inference_data_path": "",
+        "math_inference_data_path": "",
+        "composition_inference_data_path": "",
     }
     evaluate_all_question_types_and_print_report(data_paths, *sys.argv[1:])

--- a/eval.py
+++ b/eval.py
@@ -25,17 +25,6 @@ def call_api(client, model_id, input_text):
     )
     return response.output_text
 
-def custom_round(x, decimal_places=2):
-    """Rounds decimals to 2 d.p."""
-    str_x = f"{x:.10f}"
-    before_decimal = str_x.split('.')[0]
-    after_decimal = str_x.split('.')[1]
-    leading_zeros = len(after_decimal) - len(after_decimal.lstrip('0'))
-    if leading_zeros >= 1 and before_decimal == "0":
-        return round(x, leading_zeros + 2)
-    else:
-        return round(x, decimal_places)
-
 
 def parse_answer(answer, pattern:str="so the final answer is:"):
     """Extracts number from answer."""

--- a/eval.py
+++ b/eval.py
@@ -36,15 +36,6 @@ def custom_round(x, decimal_places=2):
     else:
         return round(x, decimal_places)
 
-def normalize(res, round_to=2):
-    """Rounds and removes trailing zeros."""
-    res = custom_round(res, round_to)
-    res = str(res)
-    if "." in res:
-        while res[-1] == "0":
-            res = res[:-1]
-        res = res.strip(".")
-    return res
 
 def parse_answer(answer, pattern:str="so the final answer is:"):
     """Extracts number from answer."""

--- a/eval.py
+++ b/eval.py
@@ -12,13 +12,6 @@ from tqdm import tqdm
 openai_api_key = os.environ["OPENAI_API_KEY"]
 
 
-def call_api(client, model_id, input_text):
-    """Calls the OpenAI API with the given model and input text."""
-    response = client.responses.create(
-        model=model_id,
-        input=input_text
-    )
-    return response.output_text
 
 
 def parse_answer(answer, pattern:str="so the final answer is:"):
@@ -63,7 +56,11 @@ def evaluate_answer(question, gold_answer, response, client, eval_model_id="gpt-
     Question: {question}
     Response: {response}
     Reference: {gold_answer}''')
-    eval_response = call_api(client, eval_model_id, eval_prompt)
+    response = client.responses.create(
+        model=eval_model_id,
+        input=eval_prompt
+    )
+    eval_response = response.output_text
     if "yes" in eval_response.lower():
         result = True
     elif "no" in eval_response.lower():

--- a/eval.py
+++ b/eval.py
@@ -196,6 +196,31 @@ def discover_inference_files(output_folder, model_name, split, sampling_config=N
         return [discover_inference_files(output_folder, model_name, split, config) for config in sorted(configs)]
 
 
+def discover_all_models(output_folder, split):
+    """Auto-discover all models in the output folder based on file patterns.
+    
+    Args:
+        output_folder: Path to folder containing inference results
+        split: Data split ('dev' or 'test')
+    
+    Returns:
+        List of model names found in the output folder
+    """
+    pattern = f"{split}_*.csv"
+    files = glob.glob(os.path.join(output_folder, pattern))
+    
+    models = set()
+    for file in files:
+        filename = os.path.basename(file)
+        parts = filename.replace('.csv', '').split('_')
+        if len(parts) >= 4:
+            # Extract model name (between split and question_type)
+            model_name = parts[1]
+            models.add(model_name)
+    
+    return sorted(list(models))
+
+
 def evaluate_all_question_types_and_print_report(data_paths, data_split, output_folder=None, model_config_name=None):
     """Evaluates all commonsense-only, math-only and compositional answers of a
       model, saves 0-1 scores for each answer for each csv file (overwrites the
@@ -285,44 +310,66 @@ You have set to evaluate on the {data_split} split. Are you sure you are providi
 
 
 if __name__ == "__main__":
-    if len(sys.argv) < 4:
-        print("Usage: python eval.py <output_folder> <model_name> <split> [sampling_config]")
-        print("Example: python eval.py outputs/ meta-llama/Llama-3.2-1B-Instruct test")
-        print("Example: python eval.py outputs/ meta-llama/Llama-3.2-1B-Instruct test top_p_90")
+    if len(sys.argv) < 3:
+        print("Usage: python eval.py <output_folder> <split>")
+        print("Example: python eval.py outputs/ test")
         sys.exit(1)
 
-    output_folder, model_name, split = sys.argv[1:4]
-    sampling_config = sys.argv[4] if len(sys.argv) > 4 else None
-
-    model_short = model_name.split("/")[-1] if "/" in model_name else model_name
-    results = []
-
-    if sampling_config:
-        # Evaluate single config
-        data_paths = discover_inference_files(output_folder, model_name, split, sampling_config)
-        if not data_paths:
-            print(f"No files found for {model_name} {split} {sampling_config}")
-            sys.exit(1)
-        print(f"Evaluating {sampling_config} configuration...")
-        metrics = evaluate_all_question_types_and_print_report(data_paths, split, output_folder)
-        results.append({"model_config": f"{model_short}_{sampling_config}", **metrics})
-    else:
-        # Evaluate all configs
+    output_folder, split = sys.argv[1:3]
+    
+    # Discover all models in the output folder
+    models = discover_all_models(output_folder, split)
+    if not models:
+        print(f"No models found in {output_folder} for {split} split")
+        sys.exit(1)
+    
+    print(f"Found models: {', '.join(models)}")
+    
+    all_results = []
+    for model_name in models:
+        print(f"\n{'='*70}")
+        print(f"Evaluating model: {model_name}")
+        print(f"{'='*70}")
+        
         all_configs = discover_inference_files(output_folder, model_name, split)
         if not all_configs:
             print(f"No files found for {model_name} {split}")
-            sys.exit(1)
-
-        for i, data_paths in enumerate(all_configs):
-            config_name = list(data_paths.values())[0].split("_")[-1].replace(".csv", "")
-            print(f"\n{'=' * 50}")
+            continue
+        
+        for data_paths in all_configs:
+            # Extract full sampling config name from filename
+            sample_file = list(data_paths.values())[0]
+            filename = os.path.basename(sample_file).replace(".csv", "")
+            parts = filename.split("_")
+            # Sampling config starts after question type (commonsense/math/composition)
+            if len(parts) >= 4:
+                config_name = "_".join(parts[3:])  # Everything after question type
+            else:
+                config_name = parts[-1]
+            
+            print(f"\n{'-'*50}")
             print(f"Evaluating configuration: {config_name}")
-            print(f"{'=' * 50}")
+            print(f"{'-'*50}")
+            
+            # Determine sampling method
+            if "top_p" in config_name:
+                sampling_method = "top_p"
+            elif "min_p" in config_name:
+                sampling_method = "min_p"
+            elif "greedy" in config_name:
+                sampling_method = "greedy"
+            else:
+                sampling_method = "unknown"
+            
             metrics = evaluate_all_question_types_and_print_report(data_paths, split, output_folder)
-            results.append({"model_config": f"{model_short}_{config_name}", **metrics})
-
-    # Save results to CSV
-    results_df = pd.DataFrame(results)
-    results_csv_path = os.path.join(output_folder, f"evaluation_results_{model_short}_{split}.csv")
+            all_results.append({
+                "model_config": f"{model_name}_{config_name}", 
+                "sampling_method": sampling_method,
+                **metrics
+            })
+    
+    # Save combined results
+    results_df = pd.DataFrame(all_results)
+    results_csv_path = os.path.join(output_folder, f"evaluation_results_{split}.csv")
     results_df.to_csv(results_csv_path, index=False)
-    print(f"\nResults saved to: {results_csv_path}")
+    print(f"\nCombined results saved to: {results_csv_path}")

--- a/inference.py
+++ b/inference.py
@@ -30,9 +30,8 @@ def run_inference(model: str, split: str, tp_size: int, output_folder: str,
     data = pd.read_csv(f"data/agentcoma_{split}.csv")
     print("Data loaded!")
 
-    out = []
-
     for question_type in question_types:
+        out = []
         prompts = [templates[f"few_shot_cot_{question_type}"].format(
              question=q) for q in data[f'question_{question_type}']]
 
@@ -49,7 +48,7 @@ def run_inference(model: str, split: str, tp_size: int, output_folder: str,
         for n, output in tqdm(enumerate(outputs)):
                 generated_text = output.outputs[0].text
                 generated_text_clean = generated_text.split("Question:")[0]
-                out.append({"idx": {n}, "generation": generated_text_clean})
+                out.append({"idx": n, "generation": generated_text_clean})
         out_df = pd.DataFrame(out)
         out_df.to_csv(
           os.path.join(

--- a/inference.py
+++ b/inference.py
@@ -7,13 +7,32 @@ from vllm import LLM, SamplingParams
 
 from prompts import templates
 
+## Model configurations
+MODELS = [
+    "meta-llama/Llama-3.2-1B-Instruct",
+    "meta-llama/Llama-3.2-3B-Instruct",
+    "google/gemma-3-4b-it",
+    # Add more model IDs here
+]
+
+## Sampling configurations for parameter sweeping
+SAMPLING_CONFIGS = {
+    "greedy": {"temperature": 0.0, "top_k": 1},
+    # "top_p_50": {"temperature": 0.0, "top_p": 0.5, "top_k": -1},
+    "top_p_90": {"temperature": 0.0, "top_p": 0.9, "top_k": -1},
+    # "min_p_01": {"temperature": 0.0, "min_p": 0.01, "top_k": -1},
+    "min_p_05": {"temperature": 0.0, "min_p": 0.05, "top_k": -1},
+}
+
 ## optionally uncomment and set cache path below for downloading ckpts
 # os.environ['TRANSFORMERS_CACHE'] = ""
 # os.environ['HF_HOME'] = ""
 # os.environ['HF_DATASETS_CACHE'] = ""
 
 
-def run_inference(model: str, split: str, tp_size: int, output_folder: str, max_tokens: int = 2048, max_model_len: int = 4096):
+def run_inference(
+    model: str, split: str, tp_size: int, output_folder: str, max_tokens: int = 2048, max_model_len: int = 4096, sampling_config: str = "greedy"
+):
     """Runs inference on all question types in AgentCoMa (commonsense-only,
     math-only, composition). Saves respective CSV outputs in the OUTPUT_FOLDER.
 
@@ -34,13 +53,14 @@ def run_inference(model: str, split: str, tp_size: int, output_folder: str, max_
         out = []
         prompts = [templates[f"few_shot_cot_{question_type}"].format(question=q) for q in data[f"question_{question_type}"]]
 
-        sampling_params = SamplingParams(temperature=0.0, top_k=1, max_tokens=max_tokens)
+        sampling_params = SamplingParams(max_tokens=max_tokens, **SAMPLING_CONFIGS[sampling_config])
         llm = LLM(
             model=model,
             tensor_parallel_size=int(tp_size),
             max_model_len=max_model_len,
             download_dir="",  # set the download dir
             trust_remote_code=True,
+            gpu_memory_utilization=0.4,  # Use 50% of available GPU memory
         )
 
         outputs = llm.generate(prompts, sampling_params)
@@ -50,8 +70,37 @@ def run_inference(model: str, split: str, tp_size: int, output_folder: str, max_
             generated_text_clean = generated_text.split("Question:")[0]
             out.append({"idx": n, "generation": generated_text_clean})
         out_df = pd.DataFrame(out)
-        out_df.to_csv(os.path.join(output_folder, f"{split}_{model.split('/')[1]}_{question_type}.csv"))
+        out_df.to_csv(os.path.join(output_folder, f"{split}_{model.split('/')[1]}_{question_type}_{sampling_config}.csv"))
+
+
+def run_sampling_sweep(model: str, split: str, tp_size: int, output_folder: str, max_tokens: int = 2048, max_model_len: int = 4096):
+    """Runs inference with all sampling configurations for comparison.
+
+    Usage: python inference.py sweep model_name split tp_size output_folder [max_tokens] [max_model_len]
+    Example: python inference.py sweep meta-llama/Llama-3.2-1B-Instruct dev 1 outputs/
+    """
+    for config_name in SAMPLING_CONFIGS.keys():
+        print(f"Running inference with {config_name} sampling...")
+        run_inference(model, split, tp_size, output_folder, max_tokens, max_model_len, config_name)
+
+
+def run_multi_model_sweep(split: str, tp_size: int, output_folder: str, max_tokens: int = 2048, max_model_len: int = 4096):
+    """Runs inference with all models and all sampling configurations.
+
+    Usage: python inference.py multi_sweep split tp_size output_folder [max_tokens] [max_model_len]
+    Example: python inference.py multi_sweep dev 1 outputs/
+    """
+    for model in MODELS:
+        print(f"\n{'=' * 60}")
+        print(f"Running inference for model: {model}")
+        print(f"{'=' * 60}")
+        run_sampling_sweep(model, split, tp_size, output_folder, max_tokens, max_model_len)
 
 
 if __name__ == "__main__":
-    run_inference(*sys.argv[1:])
+    if len(sys.argv) > 1 and sys.argv[1] == "sweep":
+        run_sampling_sweep(*sys.argv[2:])
+    elif len(sys.argv) > 1 and sys.argv[1] == "multi_sweep":
+        run_multi_model_sweep(*sys.argv[2:])
+    else:
+        run_inference(*sys.argv[1:])

--- a/inference.py
+++ b/inference.py
@@ -1,4 +1,4 @@
-import os 
+import os
 import pandas as pd
 import sys
 
@@ -12,18 +12,18 @@ from prompts import templates
 # os.environ['HF_HOME'] = ""
 # os.environ['HF_DATASETS_CACHE'] = ""
 
-def run_inference(model: str, split: str, tp_size: int, output_folder: str,
-                  max_tokens: int = 2048, max_model_len: int = 4096):
+
+def run_inference(model: str, split: str, tp_size: int, output_folder: str, max_tokens: int = 2048, max_model_len: int = 4096):
     """Runs inference on all question types in AgentCoMa (commonsense-only,
     math-only, composition). Saves respective CSV outputs in the OUTPUT_FOLDER.
-    
-    Args: 
+
+    Args:
         model: The Hugging Face model indentifier.
         split: Dataset split. Options: 'dev' or 'test'.
         tp_size: Size of tensor parallel.
         output_folder: Path to the output folder where to save the responses.
     """
-    assert split in ["test", "dev"], 'Allowed split values are ["test", "dev"]'    
+    assert split in ["test", "dev"], 'Allowed split values are ["test", "dev"]'
     question_types = ["commonsense", "math", "composition"]
 
     print(f"Loading {split} split...")
@@ -32,29 +32,26 @@ def run_inference(model: str, split: str, tp_size: int, output_folder: str,
 
     for question_type in question_types:
         out = []
-        prompts = [templates[f"few_shot_cot_{question_type}"].format(
-             question=q) for q in data[f'question_{question_type}']]
+        prompts = [templates[f"few_shot_cot_{question_type}"].format(question=q) for q in data[f"question_{question_type}"]]
 
-        sampling_params = SamplingParams(temperature=0.0, top_k=1,
-                                         max_tokens=max_tokens)
-        llm = LLM(model=model,
-                  tensor_parallel_size=int(tp_size),
-                  max_model_len=max_model_len, 
-                  download_dir="", # set the download dir
-                  trust_remote_code=True)
+        sampling_params = SamplingParams(temperature=0.0, top_k=1, max_tokens=max_tokens)
+        llm = LLM(
+            model=model,
+            tensor_parallel_size=int(tp_size),
+            max_model_len=max_model_len,
+            download_dir="",  # set the download dir
+            trust_remote_code=True,
+        )
 
         outputs = llm.generate(prompts, sampling_params)
         print(f"Running inference for question type {question_type}...")
         for n, output in tqdm(enumerate(outputs)):
-                generated_text = output.outputs[0].text
-                generated_text_clean = generated_text.split("Question:")[0]
-                out.append({"idx": n, "generation": generated_text_clean})
+            generated_text = output.outputs[0].text
+            generated_text_clean = generated_text.split("Question:")[0]
+            out.append({"idx": n, "generation": generated_text_clean})
         out_df = pd.DataFrame(out)
-        out_df.to_csv(
-          os.path.join(
-            output_folder, f"{split}_{model.split('/')[1]}_{question_type}.csv"
-            )
-          )
+        out_df.to_csv(os.path.join(output_folder, f"{split}_{model.split('/')[1]}_{question_type}.csv"))
+
 
 if __name__ == "__main__":
     run_inference(*sys.argv[1:])

--- a/prompts.py
+++ b/prompts.py
@@ -1,6 +1,5 @@
 templates = {
-
-"few_shot_cot_composition": """Answer the questions below step by step. Always conclude with the sentence 'So the final answer is:' followed by the final numerical answer.
+    "few_shot_cot_composition": """Answer the questions below step by step. Always conclude with the sentence 'So the final answer is:' followed by the final numerical answer.
 
 
 Question: You have a buffet plate that is 1.3 cm thick, a saucer that is 0.7 cm thick, a dinner plate that is 1.65 cm thick, and a dessert plate that is 0.93 cm thick.
@@ -23,11 +22,7 @@ So the final answer is: 17500
 Question: {question}
 
 Answer: """,
-
-
-
-
-"few_shot_cot_commonsense": """Answer the questions below step by step. Always conclude with the sentence 'So the final answer is:' followed by the final answer.
+    "few_shot_cot_commonsense": """Answer the questions below step by step. Always conclude with the sentence 'So the final answer is:' followed by the final answer.
 
 
 Question: You have a buffet plate, a saucer, a dinner plate, and a dessert plate.
@@ -48,11 +43,7 @@ So the final answer is: Kuala Lumpur and Dubai
 Question: {question}
 
 Answer: """,
-
-
-
-
-"few_shot_cot_math": """Answer the questions below step by step. Always conclude with the sentence 'So the final answer is:' followed by the final numerical answer.
+    "few_shot_cot_math": """Answer the questions below step by step. Always conclude with the sentence 'So the final answer is:' followed by the final numerical answer.
 
 
 Question: You have a buffet plate that is 1.3 cm thick, a saucer that is 0.7 cm thick, a dinner plate that is 1.65 cm thick, and a dessert plate that is 0.93 cm thick.
@@ -71,6 +62,5 @@ So the final answer is: 17500
 
 Question: {question}
 
-Answer: """
-
+Answer: """,
 }

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,2 @@
+line-length=144
+indent-width=4


### PR DESCRIPTION
## What

- `out` is not reset when iterating through `question_types`
- as a result, the repeated calls of `out_df.to_csv` call writes additional responses to the csv, which makes the csv have additional responses not expected by `eval.py`
- e.g. 
  1. first inference common sense questions, append those responses to `out`
  2. convert `out` to a dataframe, then write common sense responses out to the csv
  3. inference math questions, append responses to `out`
  4. at this point, out still contains responses from common sense questions
  5. when we convert `out` to a dataframe and write it out to a csv again, this csv will contain responses to BOTH math and common sense questions

## Reproduction

- I ran `inference.py` locally with a 5090, using python 3.11, torch 2.8.0, cuda 12.8
- I followed the commands in the README modified for my single GPU set up:

```
CUDA_VISIBLE_DEVICES=0 python inference.py meta-llama/Llama-3.2-1B-Instruct test 1 ~/outputs
```

- when attempting to run `eval.py`, this [assert statement fails](https://github.com/lisaalaz/agentcoma-benchmark/blob/main/eval.py#L151)

## Proposed Changes

- define `out` to be within the for loop so responses do not accumulate over question types
- nit: `n` does not need `{}` brackets around it